### PR TITLE
Invalidate individual models so they can be unique on the queue

### DIFF
--- a/src/Jobs/InvalidateAutoCache.php
+++ b/src/Jobs/InvalidateAutoCache.php
@@ -3,22 +3,21 @@
 namespace Tv2regionerne\StatamicCache\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Tv2regionerne\StatamicCache\Facades\Store;
 
-class InvalidateAutoCache implements ShouldQueue
+class InvalidateAutoCache implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
      * Create a new job instance.
      */
-    public function __construct(public array $tags)
-    {
-    }
+    public function __construct(public array $tags) {}
 
     /**
      * Execute the job.
@@ -26,5 +25,13 @@ class InvalidateAutoCache implements ShouldQueue
     public function handle(): void
     {
         Store::invalidateContent($this->tags);
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return md5(json_encode($this->tags));
     }
 }

--- a/src/Jobs/InvalidateAutoCache.php
+++ b/src/Jobs/InvalidateAutoCache.php
@@ -17,7 +17,9 @@ class InvalidateAutoCache implements ShouldBeUnique, ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct(public array $tags) {}
+    public function __construct(public array $tags)
+    {
+    }
 
     /**
      * Execute the job.

--- a/src/Jobs/InvalidateAutoCacheModel.php
+++ b/src/Jobs/InvalidateAutoCacheModel.php
@@ -17,7 +17,9 @@ class InvalidateAutoCacheModel implements ShouldBeUnique, ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct(public $models) {}
+    public function __construct(public $models)
+    {
+    }
 
     /**
      * Execute the job.

--- a/src/Jobs/InvalidateAutoCacheModel.php
+++ b/src/Jobs/InvalidateAutoCacheModel.php
@@ -3,28 +3,35 @@
 namespace Tv2regionerne\StatamicCache\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Tv2regionerne\StatamicCache\Facades\Store;
 
-class InvalidateAutoCacheChunk implements ShouldQueue
+class InvalidateAutoCacheModel implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
      * Create a new job instance.
      */
-    public function __construct(public $models)
-    {
-    }
+    public function __construct(public $models) {}
 
     /**
      * Execute the job.
      */
     public function handle(): void
     {
-        Store::invalidateModels($this->models);
+        Store::invalidateModel($this->model);
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return md5($model->url);
     }
 }

--- a/src/Jobs/InvalidateAutoCacheModel.php
+++ b/src/Jobs/InvalidateAutoCacheModel.php
@@ -17,7 +17,7 @@ class InvalidateAutoCacheModel implements ShouldBeUnique, ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct(public $models)
+    public function __construct(public $model)
     {
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Tv2regionerne\StatamicCache;
 
-use Statamic\Facades\StaticCache;
 use Statamic\Providers\AddonServiceProvider;
 use Tv2regionerne\StatamicCache\Listeners\Subscriber;
 


### PR DESCRIPTION
This PR makes the InvalidateAutoCache job unique on the queue and switches from invalidating chunks to invalidating individual AutoCache models on the queue with a new InvalidateAutoCacheModel job, which are also unique on the queue.

This is an attempt to get around what we think is a race condition that is causing Autocache to become out of sync with the cached files.