### PR TITLE
Fix issues with cache clearing

### DIFF
--- a/src/Cacher/Cacher.php
+++ b/src/Cacher/Cacher.php
@@ -39,8 +39,12 @@ class Cacher extends ApplicationCacher
             ->get()
             ->each(function ($model) {
                 $this->cache->forget($this->normalizeKey('responses:'.$model->key));
+
                 $model->delete();
             });
+
+        // if we dont have a db entry we should still clear the cache
+        $this->cache->forget($this->normalizeKey('responses:'.$this->makeHash($domain.$url)));
 
         UrlInvalidated::dispatch($url, $domain);
     }

--- a/src/Store/Manager.php
+++ b/src/Store/Manager.php
@@ -107,13 +107,15 @@ class Manager
     {
         $url = class_exists(Livewire::class) ? Livewire::originalUrl() : URL::getCurrent();
 
+        $hashKey = md5($url);
+
         [$url, $domain] = $this->splitUrlAndDomain($url);
 
         if (! empty($this->cacheContent($key))) {
             StaticCache::updateOrCreate([
                 'url' => $url,
             ], [
-                'key' => md5($url),
+                'key' => $hashKey,
                 'domain' => $domain ?? '',
                 'content' => $this->cacheContent($key),
             ]);
@@ -181,9 +183,9 @@ class Manager
         $manager = app()->make(StaticCacheManager::class);
         $cache = $manager->cacheStore();
 
-        [$url, $domain] = $this->splitUrlAndDomain($url);
+        [$path, $domain] = $this->splitUrlAndDomain($url);
 
-        app(Cacher::class)->invalidateUrl($url, $domain);
+        app(Cacher::class)->invalidateUrl($path, $domain);
         $cache->forget('static-cache:responses:'.md5($url));
     }
 


### PR DESCRIPTION
This PR should solve some issues:

1. The auto cache was setting the wrong key on the database (should be the full url hash, not the path)
2. We will clear the cache even if there is no database entry for it